### PR TITLE
fix: public (cbor/json)::codec module

### DIFF
--- a/protocols/request-response/src/cbor.rs
+++ b/protocols/request-response/src/cbor.rs
@@ -46,7 +46,7 @@
 /// ```
 pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
-mod codec {
+pub mod codec {
     use std::{collections::TryReserveError, convert::Infallible, io, marker::PhantomData};
 
     use async_trait::async_trait;

--- a/protocols/request-response/src/json.rs
+++ b/protocols/request-response/src/json.rs
@@ -46,7 +46,7 @@
 /// ```
 pub type Behaviour<Req, Resp> = crate::Behaviour<codec::Codec<Req, Resp>>;
 
-mod codec {
+pub mod codec {
     use std::{io, marker::PhantomData};
 
     use async_trait::async_trait;


### PR DESCRIPTION
## Description

configuring a request_response behavior with generic codec does not allow for setting request/response size limits.

e.g. the following fails to compile since `request_response::cbor::codec` is private:
```rust
let non_default_codec = request_response::cbor::codec::Codec::<CustomRequest, CustomLargeResponse>::default()
    .set_response_size_maximum(large_response_size_max);
let request_response = request_response::Behaviour::with_codec(
    non_default_codec,
    std::iter::once((
        StreamProtocol::new("/request-response/1"),
        request_response::ProtocolSupport::Full,
    )),
    request_response::Config::default(),
);
```

## Notes & open questions

- is there an alternative to making the codec module public?

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [X] I have performed a self-review of my own code
- [X] ~~I have made corresponding changes to the documentation~~
- [X] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] A changelog entry has been made in the appropriate crates
